### PR TITLE
Compat with old routes

### DIFF
--- a/src/Middleware/AppRouter.php
+++ b/src/Middleware/AppRouter.php
@@ -102,6 +102,7 @@ class AppRouter implements MiddlewareInterface
         // Match
         // @TODO Cache routes
         $path = $request->getUri()->getPath();
+        $path = strtok($path, '?');
         $match = $this->router->match($path);
         $request = $request->withAttribute('route', $match);
 

--- a/src/Middleware/AppRouter.php
+++ b/src/Middleware/AppRouter.php
@@ -105,6 +105,10 @@ class AppRouter implements MiddlewareInterface
         $match = $this->router->match($path);
         $request = $request->withAttribute('route', $match);
 
+        // compatibility: if unset stack and HordeAuthType is 'NONE' set empty stack
+        if (!isset($match['stack']) && $match['HordeAuthType'] === 'NONE') {
+            $match['stack'] = [];
+        }
         // Stack is an array of DI keys
         // Empty array means NO more middleware besides controller
         // unset stack means DEFAULT middleware stack


### PR DESCRIPTION
Two changes in AppRouter Middleware.
- compatibility with 'HordeAuthType' => 'NONE' in routes.php
- remove query string (if any) from path before trying to match.