### PR TITLE
added DemandSessionToken and DemandAuthenticatedUser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,11 +48,7 @@ jobs:
     - name: Install horde/test dependency and other dependencies
       run: |
         ## For unclear reasons, github action fails randomly if we do not install before we require.
+        COMPOSER_ROOT_VERSION=dev-FRAMEWORK_6_0 composer config minimum-stability dev
         COMPOSER_ROOT_VERSION=dev-FRAMEWORK_6_0 composer install
-        COMPOSER_ROOT_VERSION=dev-FRAMEWORK_6_0 composer require --dev horde/test dev-FRAMEWORK_6_0 horde/log ^3
-    - name: install horde/test ^3
-      run: composer require horde/test ^3
-    - name: install horde/http ^3
-      run: composer require horde/http ^3
     - name: run phpunit
       run: phpunit --bootstrap test/Horde/Core/bootstrap.php test/Horde/Core/

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ run-tests.log
 /test/*/*/*/*.log
 /test/*/*/*/*.out
 
+/vendor
+/composer.lock
+/web
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,9 @@
         "pear/pear": "*",
         "ext-session": "*"
     },
-    "require-dev": {},
+    "require-dev": {
+        "horde/test": "dev-FRAMEWORK_6_0"
+    },
     "suggest": {
         "pear/text_captcha": "*",
         "pear/text_figlet": "*",

--- a/src/Middleware/DemandAuthenticatedUser.php
+++ b/src/Middleware/DemandAuthenticatedUser.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace Horde\Core\Middleware;
+
+use Exception;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+
+/**
+ * returns 401 response if not authenticated
+ * 
+ * Reads attribute: 
+ * - HORDE_AUTHENTICATED_USER the uid, if authenticated
+ * 
+ */
+class DemandAuthenticatedUser implements MiddlewareInterface
+{
+    private ResponseFactoryInterface $responseFactory;
+
+    public function __construct(ResponseFactoryInterface $responseFactory)
+    {
+        $this->responseFactory = $responseFactory;
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        if ($request->getAttribute('HORDE_AUTHENTICATED_USER')) {
+            return $handler->handle($request);
+        }
+        return $this->responseFactory->createResponse(401);
+    }
+}

--- a/src/Middleware/DemandAuthenticatedUser.php
+++ b/src/Middleware/DemandAuthenticatedUser.php
@@ -11,11 +11,17 @@ use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 
 /**
- * returns 401 response if not authenticated
+ * DemandAuthenticatedUser middleware
+ * Returns 401 response if not authenticated
  * 
  * Reads attribute: 
  * - HORDE_AUTHENTICATED_USER the uid, if authenticated
  * 
+ * @author    Mahdi Pasche <pasche@b1-systems.de>
+ * @category  Horde
+ * @copyright 2013-2021 Horde LLC
+ * @license   http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package   Core
  */
 class DemandAuthenticatedUser implements MiddlewareInterface
 {
@@ -31,6 +37,6 @@ class DemandAuthenticatedUser implements MiddlewareInterface
         if ($request->getAttribute('HORDE_AUTHENTICATED_USER')) {
             return $handler->handle($request);
         }
-        return $this->responseFactory->createResponse(401);
+        return $this->responseFactory->createResponse(401, 'Authenticated user not found.');
     }
 }

--- a/src/Middleware/DemandSessionToken.php
+++ b/src/Middleware/DemandSessionToken.php
@@ -14,12 +14,15 @@ use \Horde_Registry;
 use \Horde_Session;
 use \Horde_Exception;
 
-
 /**
  * DemandSessionToken middleware
- *
- * Checks if the current session token in the Horde-Session-Token header.
+ * Checks if the current session token is in the Horde-Session-Token header.
  * 
+ * @author    Mahdi Pasche <pasche@b1-systems.de>
+ * @category  Horde
+ * @copyright 2013-2021 Horde LLC
+ * @license   http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package   Core
  */
 class DemandSessionToken implements MiddlewareInterface
 {
@@ -39,9 +42,8 @@ class DemandSessionToken implements MiddlewareInterface
     }
 
     /**
-     * checks for a valid session token
-     * DemandSessionToken
-     * returns 403 response if token is invalid or not found
+     * Checks for a valid session token
+     * Returns 403 response if token is invalid or not found
      * 
      * @param ServerRequestInterface $request
      * @param RequestHandlerInterface $handler
@@ -50,7 +52,7 @@ class DemandSessionToken implements MiddlewareInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        // using getHeaderLine forces the request to have a single value for the header to be valid
+        // Using getHeaderLine forces the request to have a single value for the header to be valid
         $token = $request->getHeaderLine('Horde-Session-Token');
         try {
             $this->session->checkToken($token);

--- a/src/Middleware/DemandSessionToken.php
+++ b/src/Middleware/DemandSessionToken.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+namespace Horde\Core\Middleware;
+
+use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use \Horde_Registry;
+use \Horde_Session;
+use \Horde_Exception;
+
+
+/**
+ * DemandSessionToken middleware
+ *
+ * Checks if the current session token in the Horde-Session-Token header.
+ * 
+ */
+class DemandSessionToken implements MiddlewareInterface
+{
+    protected ResponseFactoryInterface $responseFactory;
+    protected StreamFactoryInterface $streamFactory;
+    protected Horde_Session $session;
+
+    public function __construct(
+        ResponseFactoryInterface $responseFactory,
+        StreamFactoryInterface $streamFactory,
+        Horde_Session $session
+    )
+    {
+        $this->responseFactory = $responseFactory;
+        $this->streamFactory = $streamFactory;
+        $this->session = $session;
+    }
+
+    /**
+     * checks for a valid session token
+     * DemandSessionToken
+     * returns 403 response if token is invalid or not found
+     * 
+     * @param ServerRequestInterface $request
+     * @param RequestHandlerInterface $handler
+     * 
+     * @return ResponseInterface
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        // using getHeaderLine forces the request to have a single value for the header to be valid
+        $token = $request->getHeaderLine('Horde-Session-Token');
+        try {
+            $this->session->checkToken($token);
+        } catch (Horde_Exception $e) {
+            return $this->responseFactory->createResponse(403, 'Horde-Session-Token header missing or incorrect.');
+        }
+        return $handler->handle($request);
+    }
+}

--- a/test/Horde/Core/Middleware/DemandAuthenticatedUserTest.php
+++ b/test/Horde/Core/Middleware/DemandAuthenticatedUserTest.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright 2016-2021 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category Horde
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package  Core
+ */
+namespace Horde\Core\Middleware;
+
+use \Horde_Test_Case as HordeTestCase;
+
+use \Horde_Session;
+use \Horde_Exception;
+
+
+class DemandAuthenticatedUserTest extends HordeTestCase
+{
+    use SetUpTrait;
+
+    protected function getMiddleware()
+    {
+        return new DemandAuthenticatedUser(
+            $this->responseFactory
+        );
+    }
+
+    public function testAttributeMissing()
+    {
+        $middleware = $this->getMiddleware();
+
+        $request = $this->requestFactory->createServerRequest('GET', '/test');
+        $response = $middleware->process($request, $this->handler);
+
+        $this->assertEquals(401, $response->getStatusCode());
+    }
+
+    public function testAttributeExistsButEmpty()
+    {
+        $middleware = $this->getMiddleware();
+
+        $request = $this->requestFactory->createServerRequest('GET', '/test')
+            ->withAttribute('HORDE_AUTHENTICATED_USER', '');
+        $response = $middleware->process($request, $this->handler);
+
+        $this->assertEquals(401, $response->getStatusCode());
+    }
+
+    public function testAttributeExistsAndNotEmpty()
+    {
+        $middleware = $this->getMiddleware();
+
+        $request = $this->requestFactory->createServerRequest('GET', '/test')
+            ->withAttribute('HORDE_AUTHENTICATED_USER', 'testUser');
+        $response = $middleware->process($request, $this->handler);
+
+        $this->assertEquals($this->defaultPayloadResponse, $response);
+    }
+}

--- a/test/Horde/Core/Middleware/DemandSessionTokenTest.php
+++ b/test/Horde/Core/Middleware/DemandSessionTokenTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright 2016-2021 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category Horde
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package  Core
+ */
+namespace Horde\Core\Middleware;
+
+use \Horde_Test_Case as HordeTestCase;
+
+use \Horde_Session;
+use \Horde_Exception;
+
+class DemandSessionTokenTest extends HordeTestCase
+{
+    use SetUpTrait;
+
+    protected function getMiddleware()
+    {
+        return new DemandSessionToken(
+            $this->responseFactory,
+            $this->streamFactory,
+            $this->session
+        );
+    }
+
+    public function testSessionTokenMissing()
+    {
+        $middleware = $this->getMiddleware();
+
+        $this->session->method('checkToken')->willThrowException(new Horde_Exception("test"));
+        $request = $this->requestFactory->createServerRequest('GET', '/test');
+        $response = $middleware->process($request, $this->handler);
+
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+
+    public function testSessionTokenCorrect()
+    {
+        $middleware = $this->getMiddleware();
+
+        $request = $this->requestFactory->createServerRequest('GET', '/test');
+        $response = $middleware->process($request, $this->handler);
+
+        $this->assertEquals($this->defaultPayloadResponse, $response);
+    }
+}

--- a/test/Horde/Core/Middleware/SetUpTrait.php
+++ b/test/Horde/Core/Middleware/SetUpTrait.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright 2016-2021 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ *
+ * @category Horde
+ * @license  http://www.horde.org/licenses/lgpl21 LGPL 2.1
+ * @package  Core
+ */
+namespace Horde\Core\Middleware;
+
+use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+use \Horde\Core\Middleware\DemandSessionToken;
+use \Horde\Http\RequestFactory;
+use \Horde\Http\StreamFactory;
+use \Horde\Http\ResponseFactory;
+use \Horde\Http\Server\RampageRequestHandler;
+use \Horde_Session;
+use \Horde_Registry;
+use \Horde_Exception;
+
+trait SetUpTrait
+{
+    protected function setUp(): void
+    {
+        $this->requestFactory = new RequestFactory();
+        $this->streamFactory = new StreamFactory();
+        $this->responseFactory = new ResponseFactory();
+        $this->session = $this->createMock(Horde_Session::class);
+        $this->registry = $this->createMock(Horde_Registry::class);
+
+        $this->defaultPayloadResponse = $this->responseFactory->createResponse(200);
+        $this->defaultPayloadHandler = $this->createMock(RequestHandlerInterface::class);
+        $this->defaultPayloadHandler->method('handle')->willReturn($this->defaultPayloadResponse);
+
+        $this->handler = new RampageRequestHandler(
+            $this->responseFactory,
+            $this->streamFactory,
+            [],
+            $this->defaultPayloadHandler
+        );
+    }
+}


### PR DESCRIPTION
New Middlewares:
- DemandSessionToken: Returns 403 if `Horde-Session-Token` request header is not set or invalid
- DemandAuthenticatedUser: Returns 401 if `HORDE_AUTHENTICATED_USER` request attribute is not set or empty