### PR TITLE
php8.0 compat: remove obsolete parameter errcontext from errorHandler

### DIFF
--- a/lib/Horde/ErrorHandler.php
+++ b/lib/Horde/ErrorHandler.php
@@ -148,10 +148,8 @@ HTML;
      * @param string $errstr     See set_error_handler().
      * @param string $errfile    See set_error_handler().
      * @param integer $errline   See set_error_handler().
-     * @param array $errcontext  See set_error_handler().
      */
-    public static function errorHandler($errno, $errstr, $errfile, $errline,
-                                        $errcontext)
+    public static function errorHandler($errno, $errstr, $errfile, $errline)
     {
         $er = error_reporting();
 


### PR DESCRIPTION
The signature of the callback passed into [`set_error_handler` has changed in PHP 8.0](https://www.php.net/manual/en/function.set-error-handler.php#refsect1-function.set-error-handler-changelog). The parameter `errcontext` has been removed in PHP 8.0 after it had been deprecated since PHP 7.2.

This PR adapts Horde's errorHandler accordingly.