### PR TITLE
Improved error handling

### DIFF
--- a/src/Middleware/ErrorFilter.php
+++ b/src/Middleware/ErrorFilter.php
@@ -4,12 +4,16 @@ declare(strict_types=1);
 
 namespace Horde\Core\Middleware;
 
+use Horde;
+use Horde\Http\ResponseFactory;
+use Horde\Http\StreamFactory;
+use Horde_ErrorHandler;
+use Horde_Registry;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Horde_Registry;
-use Horde_Application;
+use Throwable;
 
 /**
  * ErrorFilter middleware
@@ -31,9 +35,58 @@ use Horde_Application;
  */
 class ErrorFilter implements MiddlewareInterface
 {
+    protected Horde_Registry $registry;
+    protected ResponseFactory $responseFactory;
+    protected StreamFactory $streamFactory;
+
+    public function __construct(
+        Horde_Registry $registry,
+        ResponseFactory $responseFactory,
+        StreamFactory $streamFactory
+    ) {
+        $this->registry = $registry;
+        $this->responseFactory = $responseFactory;
+        $this->streamFactory = $streamFactory;
+    }
+
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        // TODO:
-        return $handler->handle($request);
+        try {
+            return $handler->handle($request);
+        } catch (Throwable $throwable) {
+            Horde::log($throwable, 'EMERG');
+            return $this->getErrorResponse($request, $throwable);
+        }
+    }
+
+    protected function getErrorResponse(ServerRequestInterface $request, Throwable $throwable): ResponseInterface
+    {
+        $isAdmin = $this->registry->isAdmin();
+        $acceptsJson = in_array('application/json', array_map(fn($val) => strtolower($val), $request->getHeader('Accept')));
+        if ($acceptsJson){
+            return $this->getJsonResponse($throwable, $isAdmin);
+        } else {
+            return $this->getHtmlResponse($throwable, $isAdmin);
+        }
+    }
+
+    protected function getJsonResponse(Throwable $throwable, bool $isAdmin = false): ResponseInterface
+    {
+        $json = json_encode([
+            'message' => $throwable->getMessage(),
+            'code' => $throwable->getCode(),
+            'trace' => $isAdmin ? $throwable->getTrace() : [],
+        ]);
+        $stream = $this->streamFactory->createStream($json);
+        return $this->responseFactory->createResponse(500, 'Internal Server Error')
+            ->withBody($stream)
+            ->withHeader('Content-Type', 'application/json');
+    }
+
+    protected function getHtmlResponse(Throwable $throwable, bool $isAdmin = false): ResponseInterface
+    {
+        $stream = $this->streamFactory->createStream(Horde_ErrorHandler::getHtmlForError($throwable, $isAdmin));
+        return $this->responseFactory->createResponse(500, 'Internal Server Error')
+            ->withBody($stream);
     }
 }

--- a/src/Middleware/HordeCore.php
+++ b/src/Middleware/HordeCore.php
@@ -56,13 +56,15 @@ class HordeCore implements MiddlewareInterface
             $injector->setInstance(ResponseFactoryInterface::class, new ResponseFactory());
         }
 
-
-        // Detect correct app
         $registry = $injector->getInstance('Horde_Registry');
-        $request = $request->withAttribute('registry', $registry);
+        // First middleware should be ErrorFilter to catch all errors
+        $handler->addMiddleware(new ErrorFilter($registry, new ResponseFactory(), new StreamFactory()));
+        // Detect correct app
         $handler->addMiddleware(new AppFinder($registry, new ResponseFactory(), new StreamFactory()));
         // Find route inside detected app
         $handler->addMiddleware(new AppRouter($registry, $injector->get('Horde_Routes_Mapper'), $injector));
+
+        $request = $request->withAttribute('registry', $registry);
         return $handler->handle($request);
     }
 }

--- a/src/Middleware/HordeCore.php
+++ b/src/Middleware/HordeCore.php
@@ -60,7 +60,7 @@ class HordeCore implements MiddlewareInterface
         // Detect correct app
         $registry = $injector->getInstance('Horde_Registry');
         $request = $request->withAttribute('registry', $registry);
-        $handler->addMiddleware(new AppFinder($registry));
+        $handler->addMiddleware(new AppFinder($registry, new ResponseFactory(), new StreamFactory()));
         // Find route inside detected app
         $handler->addMiddleware(new AppRouter($registry, $injector->get('Horde_Routes_Mapper'), $injector));
         return $handler->handle($request);

--- a/test/Middleware/AppFinderTest.php
+++ b/test/Middleware/AppFinderTest.php
@@ -15,7 +15,8 @@ namespace Horde\Core\Test\Middleware;
 
 use Exception;
 use Horde\Core\Middleware\AppFinder;
-
+use Horde\Http\ResponseFactory;
+use Horde\Http\StreamFactory;
 use Horde\Test\TestCase;
 
 use Horde_Registry;
@@ -27,7 +28,9 @@ class AppFinderTest extends TestCase
     protected function getMiddleware()
     {
         return new AppFinder(
-            $this->registry
+            $this->registry,
+            new ResponseFactory(),
+            new StreamFactory()
         );
     }
 
@@ -86,8 +89,9 @@ class AppFinderTest extends TestCase
         });
 
         $middleware = $this->getMiddleware();
-        $this->expectException(Exception::class);
-        $middleware->process($request, $this->handler);
+        //$this->expectException(Exception::class);
+        $response = $middleware->process($request, $this->handler);
+        $this->assertSame(404, $response->getStatusCode());
     }
 
     /**
@@ -137,8 +141,8 @@ class AppFinderTest extends TestCase
         });
 
         $middleware = $this->getMiddleware();
-        $this->expectException(Exception::class);
-        $middleware->process($request, $this->handler);
+        $response = $middleware->process($request, $this->handler);
+        $this->assertSame(404, $response->getStatusCode());
     }
 
     /**
@@ -188,8 +192,8 @@ class AppFinderTest extends TestCase
 
         $middleware = $this->getMiddleware();
 
-        $this->expectException(Exception::class);
-        $middleware->process($request, $this->handler);
+        $response = $middleware->process($request, $this->handler);
+        $this->assertSame(404, $response->getStatusCode());
     }
 
     /**
@@ -213,8 +217,8 @@ class AppFinderTest extends TestCase
 
         $middleware = $this->getMiddleware();
 
-        $this->expectException(Exception::class);
-        $middleware->process($request, $this->handler);
+        $response = $middleware->process($request, $this->handler);
+        $this->assertSame(404, $response->getStatusCode());
     }
 
 
@@ -236,8 +240,8 @@ class AppFinderTest extends TestCase
         });
 
         $middleware = $this->getMiddleware();
-        $this->expectException(Exception::class);
-        $middleware->process($request, $this->handler);
+        $response = $middleware->process($request, $this->handler);
+        $this->assertSame(404, $response->getStatusCode());
     }
 
     public function testFindAppBehindDifferentApp()
@@ -333,7 +337,7 @@ class AppFinderTest extends TestCase
         });
 
         $middleware = $this->getMiddleware();
-        $this->expectException(Exception::class);
-        $middleware->process($request, $this->handler);
+        $response = $middleware->process($request, $this->handler);
+        $this->assertSame(404, $response->getStatusCode());
     }
 }


### PR DESCRIPTION
- `AppFinder` will now return a `404 Not Found` response instead of causing an exception if an app could not be found. A message will be logged with log level `INFO`
- Exceptions handled by `Horde_ErrorHandler` will now return a reponse with status code `500 Internal Server Error`. Previously it was `200`
- Refactored html creation logic in `Horde_ErrorHandler`
- Implemented `ErrorFilter` middleware and added to top of middleware stack. Exceptions caused while using the middleware stack will now be handled by this class instead of `Horde_ErrorHandler`. 
- `ErrorFilter` middleware will return a json encoded response if the requests `Accept` header contains `application/json`. Otherwise the usual html error response will be returned.