### PR TITLE
do not lowercase driver names that are FQNs of PHP classes

### DIFF
--- a/lib/Horde/Core/Factory/SessionHandler.php
+++ b/lib/Horde/Core/Factory/SessionHandler.php
@@ -39,7 +39,10 @@ class Horde_Core_Factory_SessionHandler extends Horde_Core_Factory_Injector
         }
         $params = Horde::getDriverConfig('sessionhandler', $driver);
 
-        $driver = basename(Horde_String::lower($driver));
+        if (strpos($driver, "\\") === false) {
+            $driver = Horde_String::lower($driver);
+        }
+        $driver = basename($driver);
         $noset = false;
 
         switch ($driver) {


### PR DESCRIPTION
Without this change, SessionHandler storage drivers could only be added by adding new classes to the horde/sessionhandler package. There are situations when this is undesirable, e.g. if an app package wants to use its own custom SessionHandler storage driver that would not be useful on its own without the app. With this small change in the driver loading code, a driver class can now be part of any package, given that it is configured in Horde's config with its FQN, e.g.: "conf['sessionhandler']['type'] = '\Horde\Acme\SessionHandler\Storage\Acme';".