### PR TITLE
allow to use 'authenticate' without logging in

### DIFF
--- a/lib/Horde/Core/Auth/Application.php
+++ b/lib/Horde/Core/Auth/Application.php
@@ -128,10 +128,12 @@ class Horde_Core_Auth_Application extends Horde_Auth_Base
             return false;
         }
 
-        try {
-            list($userId, $credentials) = $this->runHook(trim($userId), $credentials, 'preauthenticate', 'authenticate');
-         } catch (Horde_Auth_Exception $e) {
-            return false;
+        if ($login) {
+            try {
+                list($userId, $credentials) = $this->runHook(trim($userId), $credentials, 'preauthenticate', 'authenticate');
+             } catch (Horde_Auth_Exception $e) {
+                return false;
+            }
         }
 
         if ($this->_base) {
@@ -141,7 +143,9 @@ class Horde_Core_Auth_Application extends Horde_Auth_Base
         } elseif (!parent::authenticate($userId, $credentials, $login)) {
             return false;
         }
-
+        if (!$login) {
+            return true;
+        }
         /* Remember the user's mode choice, if applicable. */
         if (!empty($credentials['mode'])) {
             $this->_view = $credentials['mode'];

--- a/lib/Horde/Core/Factory/Auth.php
+++ b/lib/Horde/Core/Factory/Auth.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * A Horde_Injector:: based Horde_Auth:: factory.
  *
@@ -109,6 +110,17 @@ class Horde_Core_Factory_Auth extends Horde_Core_Factory_Base
             }
             break;
 
+        case 'horde_auth_fallback':
+            // Both of these params are required, but we need to skip if
+            // non-existent to return a useful error message later.
+            if (!empty($params['primary_driver'])) {
+                $params['primary_driver'] = $this->_create($params['primary_driver']['driver'], $params['primary_driver']['params']);
+            }
+            if (!empty($params['fallback_driver'])) {
+                $params['fallback_driver'] = $this->_create($params['fallback_driver']['driver'], $params['fallback_driver']['params']);
+            }
+            break;
+
         case 'horde_auth_cyrsql':
             $imap_config = array(
                 'hostspec' => empty($params['cyrhost']) ? null : $params['cyrhost'],
@@ -188,5 +200,4 @@ class Horde_Core_Factory_Auth extends Horde_Core_Factory_Base
 
         return $auth_ob;
     }
-
 }


### PR DESCRIPTION
authenticate has a `$login` parameter that should cause the method to just check credentials if it is set to `false`.

With this change that actually does what is it supposed to. 